### PR TITLE
Dev

### DIFF
--- a/server-to-twint/.gcloudignore
+++ b/server-to-twint/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg

--- a/server-to-twint/app.yaml
+++ b/server-to-twint/app.yaml
@@ -1,5 +1,5 @@
 runtime: python
-env: flex
+# env: flex
 entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
     python_version: 3

--- a/server-to-twint/app.yaml
+++ b/server-to-twint/app.yaml
@@ -1,6 +1,3 @@
-runtime: python
-# env: flex
+runtime: python37
 entrypoint: gunicorn -b :$PORT main:app
-runtime_config:
-    python_version: 3
 service: twint-geo


### PR DESCRIPTION
making sure we can actually deploy properly without spending hundreds of dollars a month.
This PR removes the `flex` environment tag on the file that specifies what is being deployed.
by default environments are run as `standard` as opposed to flex. 

In our case at one point python3 only lived on flex environments, but now there is a standard environment for it, so we will use that and stay on the free tier of usage as long as Google tiers it.


